### PR TITLE
Fix default key validation

### DIFF
--- a/nasti/nastifile.py
+++ b/nasti/nastifile.py
@@ -51,6 +51,7 @@ class UnmentionedFilesResultItem:
 class NastiFile:
     MUTATIONS_KEY="mutations"
     NAME_KEY="name"
+    DEFAULT_KEY="default"
     PROMPT_KEY="prompt"
     REPLACE_KEY="replace"
     FILES_KEY="files"
@@ -171,10 +172,12 @@ class NastiFile:
             self.FILES_KEY, 
             self.HELP_KEY, 
             self.VALIDATION_KEY,
+            self.DEFAULT_KEY,
         ]
+        # Exit the app
         for key in mutation_config:
             if not key in valid_keys:
-                raise exceptions.NastiFileUnknownKeysException(f"Error: Invalid key in mutation config: {key}")
+                raise exceptions.NastiFileUnknownKeysException(f"Error: invalid key in mutation config: {key}")
 
     def __set_path(self, path):
         if not path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "NASTI"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
   { name="Adam Drew", email="adamrdrew@live.com" },
 ]

--- a/tests/hooks/nasti.yaml
+++ b/tests/hooks/nasti.yaml
@@ -7,8 +7,8 @@ mutations:
   - name: "example_mutation"
     prompt: "Example Mutation"
     help: "Help for an example mutation"
-    replace: "example text to replace"
+    replace: "input_from_user"
     default: "{{ app_name }}"
-    files: []
+    files: ["nasti.yaml"]
     validation:
       kind: "slug"

--- a/tests/nastifiles/valid/nasti.yaml
+++ b/tests/nastifiles/valid/nasti.yaml
@@ -4,7 +4,8 @@ mutations:
     prompt: "Example Mutation"
     help: "Help for an example mutation"
     replace: "example text to replace"
+    default: "{{ app_name }}"
     files:
-      - "local_config.json"
+      - "nasti.yaml"
     validation:
       kind: "slug"


### PR DESCRIPTION
We missed including the "default" mutation key in tests AND in the key validation code so tests would pass but you could end up with a validation failure if default was in the mutation. This fixes that, improves some test files, and bumps version.